### PR TITLE
bump gateway timeout to 24 hours to match infra

### DIFF
--- a/gateway/handlers/flows.go
+++ b/gateway/handlers/flows.go
@@ -155,7 +155,7 @@ func AddFlowHandler(db *gorm.DB) http.HandlerFunc {
 		log.Println("Initialized IO List")
 
 		log.Println("Submitting IO List")
-		submittedIoList := ipwl.SubmitIoList(ioList, "", 60, []string{})
+		submittedIoList := ipwl.SubmitIoList(ioList, "", 60 * 24, []string{})
 		log.Println("pinning submitted IO List")
 		submittedIoListCid, err := pinIoList(submittedIoList)
 		if err != nil {


### PR DESCRIPTION
## What type of PR is this? 

- 🔋 Optimization

## Description

This gives our compute node 24 hours to finish a job instead of one hour. This matches the infra default timeout and allows for fire and forgetting of larger calculations. 


## Steps to Test

CI should be good enough to make sure it doesn't break anything. Then I can kick off up a bunch of long jobs in prod to edge test.

## Relevant GIF 

<img width="498" alt="Screenshot 2023-12-05 at 12 01 28 PM" src="https://github.com/labdao/lab-exchange/assets/9427089/2ed92e98-8dc0-4299-9bed-9ec8d73e93a3">
