### PR TITLE
Patch app auth

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -146,5 +146,6 @@ jobs:
       build-args: |
         NEXT_PUBLIC_BACKEND_URL=${{ matrix.backends.url }}
         NEXT_PUBLIC_IPFS_GATEWAY_ENDPOINT=${{ matrix.backends.gateway }}
+        NEXT_PUBLIC_PRIVY_APP_ID=${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID }}
       deploy-environment: ${{ matrix.backend.env }}
     secrets: inherit


### PR DESCRIPTION
## What type of PR is this? 

- 🐛 Bug Fix

## Description

When running the GitHub action to build the frontend container, we need to ensure `NEXT_PUBLIC_PRIVY_APP_ID` is passed as a build arg.