### PR TITLE
revert default tool to one in prod db

### DIFF
--- a/frontend/app/tasks/[slug]/page.tsx
+++ b/frontend/app/tasks/[slug]/page.tsx
@@ -48,7 +48,7 @@ export default function TaskDetail({ params }: { params: { slug: string } }) {
       name: "protein design",
       slug: "protein-design", //Could fetch by a slug or ID, whatever you want the url to be
       default_tool: {
-        CID: "QmcHrUAtyi68DH1wvMc5kHjh2ysze3YQ97CQLvVTS2dMkN",
+        CID: "QmYmKL9fCzxoEQAEvCtLZHXXwjJWdn7bbRE9afTXV5cB3v",
       },
     }),
     []


### PR DESCRIPTION
## What type of PR is this? 
_Remove the categories that do not apply_

- 🐛 Bug Fix

## Description

Colabdesign v0.5 CID now exists in prod DB. This updates the default tool in the experiments form to it